### PR TITLE
Fix and enable actions, add tests for all supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+sudo: required
+dist: trusty
+python:
+    - "2.7"
+env:
+    - CKAN_VERSION=dev-v2.6
+    - CKAN_VERSION=release-v2.5-latest
+    - CKAN_VERSION=release-v2.4-latest
+    - CKAN_VERSION=release-v2.3-latest
+services:
+    - postgresql
+    - redis-server
+install:
+    - bash bin/travis-build.bash
+script: sh bin/travis-run.sh
+after_success:
+    - coveralls
+cache:
+  directories:
+    - $HOME/.cache/pip

--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -3,16 +3,20 @@ set -e
 
 echo "This is travis-build.bash..."
 
+echo "Postgres version"
+psql --version
+
 echo "Installing the packages that CKAN requires..."
 sudo apt-get update -qq
-sudo apt-get install postgresql-$PGVERSION solr-jetty libcommons-fileupload-java:amd64=1.2.2-1
+sudo apt-get install solr-jetty
 
 echo "Installing CKAN and its Python dependencies..."
 git clone https://github.com/ckan/ckan
 cd ckan
-export latest_ckan_release_branch=`git branch --all | grep remotes/origin/release-v | sort -r | sed 's/remotes\/origin\///g' | head -n 1`
-echo "CKAN branch: $latest_ckan_release_branch"
-git checkout $latest_ckan_release_branch
+if [ $CKAN_VERSION != 'master' ]
+then
+    git checkout $CKAN_VERSION
+fi
 python setup.py develop
 pip install -r requirements.txt --allow-all-external
 pip install -r dev-requirements.txt --allow-all-external

--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -38,6 +38,7 @@ cd -
 
 echo "Installing ckanext-rq and its requirements..."
 python setup.py develop
+pip install -r requirements.txt
 pip install -r dev-requirements.txt
 
 echo "Moving test.ini into a subdir..."

--- a/ckanext/rq/action.py
+++ b/ckanext/rq/action.py
@@ -1,28 +1,21 @@
 # encoding: utf-8
 
 import logging
-import json
-import datetime
-import uuid
-
-from dateutil.parser import parse as parse_date
-
-import ckan.lib.helpers as h
 import ckan.lib.navl.dictization_functions
 import ckan.logic as logic
 import ckan.plugins as p
-from ckan.common import config
 
-import ckanext.shift.schema
-import jobs
+from ckanext.rq import jobs
+from ckanext.rq import schema
 
 log = logging.getLogger(__name__)
 _get_or_bust = logic.get_or_bust
-_validate = ckan.lib.navl.dictization_functions.validate
+_validate = ckan.logic.validate
 _check_access = p.toolkit.check_access
 NotFound = p.toolkit.ObjectNotFound
 
-@_validate(ckanext.rq.schema.job_list_schema)
+
+@_validate(schema.job_list_schema)
 def job_list(context, data_dict):
     '''List enqueued background jobs.
 
@@ -65,7 +58,7 @@ def job_show(context, data_dict):
         raise NotFound
 
 
-@_validate(ckanext.rq.schema.job_clear_schema)
+@_validate(schema.job_clear_schema)
 def job_clear(context, data_dict):
     '''Clear background job queues.
 

--- a/ckanext/rq/plugin.py
+++ b/ckanext/rq/plugin.py
@@ -1,9 +1,21 @@
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 
+from ckanext.rq.action import (
+    job_list, job_show, job_clear, job_cancel
+)
+from ckanext.rq.auth import (
+    job_list as job_list_auth,
+    job_show as job_show_auth,
+    job_clear as job_clear_auth,
+    job_cancel as job_cancel_auth
+)
+
 
 class RqPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
+    plugins.implements(plugins.IActions)
+    plugins.implements(plugins.IAuthFunctions)
 
     # IConfigurer
 
@@ -11,3 +23,23 @@ class RqPlugin(plugins.SingletonPlugin):
         toolkit.add_template_directory(config_, 'templates')
         toolkit.add_public_directory(config_, 'public')
         toolkit.add_resource('fanstatic', 'rq')
+
+    # IActions
+
+    def get_actions(self):
+        return {
+            'job_list': job_list,
+            'job_show': job_show,
+            'job_clear': job_clear,
+            'job_cancel': job_cancel,
+        }
+
+    # IAuthFunctions
+
+    def get_auth_functions(self):
+        return {
+            'job_list': job_list_auth,
+            'job_show': job_show_auth,
+            'job_clear': job_clear_auth,
+            'job_cancel': job_cancel_auth,
+        }

--- a/ckanext/rq/tests/helpers.py
+++ b/ckanext/rq/tests/helpers.py
@@ -1,0 +1,205 @@
+import collections
+import contextlib
+import logging
+import re
+
+import rq
+from ckantoolkit import config
+from ckantoolkit.tests.helpers import FunctionalTestBase
+
+from ckan.lib.redis import connect_to_redis
+
+import ckanext.rq.jobs as jobs
+
+
+@contextlib.contextmanager
+def changed_config(key, value):
+    '''
+    Context manager for temporarily changing a config value.
+
+    Allows you to temporarily change the value of a CKAN configuration
+    option. The original value is restored once the context manager is
+    left.
+
+    Usage::
+
+        with changed_config(u'ckan.site_title', u'My Test CKAN'):
+            assert config[u'ckan.site_title'] == u'My Test CKAN'
+
+    .. seealso:: The decorator :py:func:`change_config`
+    '''
+    _original_config = config.copy()
+    config[key] = value
+    try:
+        yield
+    finally:
+        config.clear()
+        config.update(_original_config)
+
+
+class RQTestBase(object):
+    '''
+    Base class for tests of RQ functionality.
+    '''
+    def setup(self):
+        u'''
+        Delete all RQ queues and jobs.
+        '''
+        # See https://github.com/nvie/rq/issues/731
+        redis_conn = connect_to_redis()
+        for queue in rq.Queue.all(connection=redis_conn):
+            queue.empty()
+            redis_conn.srem(rq.Queue.redis_queues_keys, queue._key)
+            redis_conn.delete(queue._key)
+
+    def all_jobs(self):
+        u'''
+        Get a list of all RQ jobs.
+        '''
+        jobs = []
+        redis_conn = connect_to_redis()
+        for queue in rq.Queue.all(connection=redis_conn):
+            jobs.extend(queue.jobs)
+        return jobs
+
+    def enqueue(self, job=None, *args, **kwargs):
+        u'''
+        Enqueue a test job.
+        '''
+        if job is None:
+            job = jobs.test_job
+        return jobs.enqueue(job, *args, **kwargs)
+
+
+class FunctionalRQTestBase(FunctionalTestBase, RQTestBase):
+    '''
+    Base class for functional tests of RQ functionality.
+    '''
+    def setup(self):
+        FunctionalTestBase.setup(self)
+        RQTestBase.setup(self)
+
+
+@contextlib.contextmanager
+def recorded_logs(logger=None, level=logging.DEBUG,
+                  override_disabled=True, override_global_level=True):
+    u'''
+    Context manager for recording log messages.
+
+    :param logger: The logger to record messages from. Can either be a
+        :py:class:`logging.Logger` instance or a string with the
+        logger's name. Defaults to the root logger.
+
+    :param int level: Temporary log level for the target logger while
+        the context manager is active. Pass ``None`` if you don't want
+        the level to be changed. The level is automatically reset to its
+        original value when the context manager is left.
+
+    :param bool override_disabled: A logger can be disabled by setting
+        its ``disabled`` attribute. By default, this context manager
+        sets that attribute to ``False`` at the beginning of its
+        execution and resets it when the context manager is left. Set
+        ``override_disabled`` to ``False`` to keep the current value
+        of the attribute.
+
+    :param bool override_global_level: The ``logging.disable`` function
+        allows one to install a global minimum log level that takes
+        precedence over a logger's own level. By default, this context
+        manager makes sure that the global limit is at most ``level``,
+        and reduces it if necessary during its execution. Set
+        ``override_global_level`` to ``False`` to keep the global limit.
+
+    :returns: A recording log handler that listens to ``logger`` during
+        the execution of the context manager.
+    :rtype: :py:class:`RecordingLogHandler`
+
+    Example::
+
+        import logging
+
+        logger = logging.getLogger(__name__)
+
+        with recorded_logs(logger) as logs:
+            logger.info(u'Hello, world!')
+
+        logs.assert_log(u'info', u'world')
+    '''
+    if logger is None:
+        logger = logging.getLogger()
+    elif not isinstance(logger, logging.Logger):
+        logger = logging.getLogger(logger)
+    handler = RecordingLogHandler()
+    old_level = logger.level
+    manager_level = logger.manager.disable
+    disabled = logger.disabled
+    logger.addHandler(handler)
+    try:
+        if level is not None:
+            logger.setLevel(level)
+        if override_disabled:
+            logger.disabled = False
+        if override_global_level:
+            if (level is None) and (manager_level > old_level):
+                logger.manager.disable = old_level
+            elif (level is not None) and (manager_level > level):
+                logger.manager.disable = level
+        yield handler
+    finally:
+        logger.handlers.remove(handler)
+        logger.setLevel(old_level)
+        logger.disabled = disabled
+        logger.manager.disable = manager_level
+
+
+class RecordingLogHandler(logging.Handler):
+    u'''
+    Log handler that records log messages for later inspection.
+
+    You can inspect the recorded messages via the ``messages`` attribute
+    (a dict that maps log levels to lists of messages) or by using
+    ``assert_log``.
+
+    This class is rarely useful on its own, instead use
+    :py:func:`recorded_logs` to temporarily record log messages.
+    '''
+    def __init__(self, *args, **kwargs):
+        super(RecordingLogHandler, self).__init__(*args, **kwargs)
+        self.clear()
+
+    def emit(self, record):
+        self.messages[record.levelname.lower()].append(record.getMessage())
+
+    def assert_log(self, level, pattern, msg=None):
+        u'''
+        Assert that a certain message has been logged.
+
+        :param string pattern: A regex which the message has to match.
+            The match is done using ``re.search``.
+
+        :param string level: The message level (``'debug'``, ...).
+
+        :param string msg: Optional failure message in case the expected
+            log message was not logged.
+
+        :raises AssertionError: If the expected message was not logged.
+        '''
+        compiled_pattern = re.compile(pattern)
+        for log_msg in self.messages[level]:
+            if compiled_pattern.search(log_msg):
+                return
+        if not msg:
+            if self.messages[level]:
+                lines = u'\n    '.join(self.messages[level])
+                msg = (u'Pattern "{}" was not found in the log messages for '
+                       + u'level "{}":\n    {}').format(pattern, level, lines)
+            else:
+                msg = (u'Pattern "{}" was not found in the log messages for '
+                       + u'level "{}" (no messages were recorded for that '
+                       + u'level).').format(pattern, level)
+        raise AssertionError(msg)
+
+    def clear(self):
+        u'''
+        Clear all captured log messages.
+        '''
+        self.messages = collections.defaultdict(list)

--- a/ckanext/rq/tests/helpers.py
+++ b/ckanext/rq/tests/helpers.py
@@ -7,7 +7,7 @@ import rq
 from ckantoolkit import config
 from ckantoolkit.tests.helpers import FunctionalTestBase
 
-from ckan.lib.redis import connect_to_redis
+from ckanext.rq.redis import connect_to_redis
 
 import ckanext.rq.jobs as jobs
 

--- a/ckanext/rq/tests/test_action.py
+++ b/ckanext/rq/tests/test_action.py
@@ -1,0 +1,117 @@
+import re
+import nose
+import datetime
+
+from nose.tools import eq_ as eq, ok_ as ok, assert_raises, raises
+
+from ckantoolkit import ObjectNotFound
+from ckantoolkit.tests import helpers
+
+from ckanext.rq.tests.helpers import FunctionalRQTestBase, recorded_logs
+from ckanext.rq import jobs
+
+
+class TestJobList(FunctionalRQTestBase):
+
+    def test_all_queues(self):
+        '''
+        Test getting jobs from all queues.
+        '''
+        job1 = self.enqueue()
+        job2 = self.enqueue()
+        job3 = self.enqueue(queue=u'my_queue')
+        jobs = helpers.call_action(u'job_list')
+        eq(len(jobs), 3)
+        eq({job[u'id'] for job in jobs}, {job1.id, job2.id, job3.id})
+
+    def test_specific_queues(self):
+        '''
+        Test getting jobs from specific queues.
+        '''
+        job1 = self.enqueue()
+        job2 = self.enqueue(queue=u'q2')
+        job3 = self.enqueue(queue=u'q3')
+        job4 = self.enqueue(queue=u'q3')
+        jobs = helpers.call_action(u'job_list', queues=[u'q2'])
+        eq(len(jobs), 1)
+        eq(jobs[0][u'id'], job2.id)
+        jobs = helpers.call_action(u'job_list', queues=[u'q2', u'q3'])
+        eq(len(jobs), 3)
+        eq({job[u'id'] for job in jobs}, {job2.id, job3.id, job4.id})
+
+
+class TestJobShow(FunctionalRQTestBase):
+
+    def test_existing_job(self):
+        '''
+        Test showing an existing job.
+        '''
+        job = self.enqueue(queue=u'my_queue', title=u'Title')
+        d = helpers.call_action(u'job_show', id=job.id)
+        eq(d[u'id'], job.id)
+        eq(d[u'title'], u'Title')
+        eq(d[u'queue'], u'my_queue')
+        dt = datetime.datetime.strptime(d[u'created'], u'%Y-%m-%dT%H:%M:%S')
+        now = datetime.datetime.utcnow()
+        ok(abs((now - dt).total_seconds()) < 10)
+
+    @nose.tools.raises(ObjectNotFound)
+    def test_not_existing_job(self):
+        '''
+        Test showing a not existing job.
+        '''
+        helpers.call_action(u'job_show', id=u'does-not-exist')
+
+
+class TestJobClear(FunctionalRQTestBase):
+
+    def test_all_queues(self):
+        '''
+        Test clearing all queues.
+        '''
+        self.enqueue()
+        self.enqueue(queue=u'q')
+        self.enqueue(queue=u'q')
+        self.enqueue(queue=u'q')
+        queues = helpers.call_action(u'job_clear')
+        eq({jobs.DEFAULT_QUEUE_NAME, u'q'}, set(queues))
+        all_jobs = self.all_jobs()
+        eq(len(all_jobs), 0)
+
+    def test_specific_queues(self):
+        '''
+        Test clearing specific queues.
+        '''
+        job1 = self.enqueue()
+        job2 = self.enqueue(queue=u'q1')
+        job3 = self.enqueue(queue=u'q1')
+        job4 = self.enqueue(queue=u'q2')
+        with recorded_logs(u'ckanext.rq.action') as logs:
+            queues = helpers.call_action(u'job_clear', queues=[u'q1', u'q2'])
+        eq({u'q1', u'q2'}, set(queues))
+        all_jobs = self.all_jobs()
+        eq(len(all_jobs), 1)
+        eq(all_jobs[0], job1)
+        logs.assert_log(u'info', u'q1')
+        logs.assert_log(u'info', u'q2')
+
+
+class TestJobCancel(FunctionalRQTestBase):
+
+    def test_existing_job(self):
+        '''
+        Test cancelling an existing job.
+        '''
+        job1 = self.enqueue(queue=u'q')
+        job2 = self.enqueue(queue=u'q')
+        with recorded_logs(u'ckanext.rq.action') as logs:
+            helpers.call_action(u'job_cancel', id=job1.id)
+        all_jobs = self.all_jobs()
+        eq(len(all_jobs), 1)
+        eq(all_jobs[0], job2)
+        assert_raises(KeyError, jobs.job_from_id, job1.id)
+        logs.assert_log(u'info', re.escape(job1.id))
+
+    @raises(ObjectNotFound)
+    def test_not_existing_job(self):
+        helpers.call_action(u'job_cancel', id=u'does-not-exist')

--- a/ckanext/rq/tests/test_jobs.py
+++ b/ckanext/rq/tests/test_jobs.py
@@ -9,7 +9,11 @@ import ckanext.rq.jobs as jobs
 from ckantoolkit import config, ObjectNotFound
 from ckan import model
 
-from ckan.tests.helpers import call_action
+try:
+    from ckan.tests.helpers import call_action
+except ImportError:
+    from ckanext.rq.tests.helpers import call_action
+
 from ckanext.rq.tests.helpers import (
     changed_config, recorded_logs, RQTestBase
 )

--- a/ckanext/rq/tests/test_jobs.py
+++ b/ckanext/rq/tests/test_jobs.py
@@ -1,0 +1,258 @@
+# encoding: utf-8
+
+import datetime
+
+from nose.tools import ok_, assert_equal, raises, assert_false
+import rq
+
+import ckanext.rq.jobs as jobs
+from ckantoolkit import config, ObjectNotFound
+from ckan import model
+
+from ckan.tests.helpers import call_action
+from ckanext.rq.tests.helpers import (
+    changed_config, recorded_logs, RQTestBase
+)
+
+
+class TestQueueNamePrefixes(RQTestBase):
+
+    def test_queue_name_prefix_contains_site_id(self):
+        prefix = jobs.add_queue_name_prefix(u'')
+        ok_(config[u'ckan.site_id'] in prefix)
+
+    def test_queue_name_removal_with_prefix(self):
+        plain = u'foobar'
+        prefixed = jobs.add_queue_name_prefix(plain)
+        assert_equal(jobs.remove_queue_name_prefix(prefixed), plain)
+
+    @raises(ValueError)
+    def test_queue_name_removal_without_prefix(self):
+        jobs.remove_queue_name_prefix(u'foobar')
+
+
+class TestEnqueue(RQTestBase):
+
+    def test_enqueue_return_value(self):
+        job = self.enqueue()
+        ok_(isinstance(job, rq.job.Job))
+
+    def test_enqueue_args(self):
+        self.enqueue()
+        self.enqueue(args=[1, 2])
+        all_jobs = self.all_jobs()
+        assert_equal(len(all_jobs), 2)
+        assert_equal(len(all_jobs[0].args), 0)
+        assert_equal(all_jobs[1].args, [1, 2])
+
+    def test_enqueue_kwargs(self):
+        self.enqueue()
+        self.enqueue(kwargs={u'foo': 1})
+        all_jobs = self.all_jobs()
+        assert_equal(len(all_jobs), 2)
+        assert_equal(len(all_jobs[0].kwargs), 0)
+        assert_equal(all_jobs[1].kwargs, {u'foo': 1})
+
+    def test_enqueue_title(self):
+        self.enqueue()
+        self.enqueue(title=u'Title')
+        all_jobs = self.all_jobs()
+        assert_equal(len(all_jobs), 2)
+        assert_equal(all_jobs[0].meta[u'title'], None)
+        assert_equal(all_jobs[1].meta[u'title'], u'Title')
+
+    def test_enqueue_queue(self):
+        self.enqueue()
+        self.enqueue(queue=u'my_queue')
+        all_jobs = self.all_jobs()
+        assert_equal(len(all_jobs), 2)
+        assert_equal(all_jobs[0].origin,
+                     jobs.add_queue_name_prefix(jobs.DEFAULT_QUEUE_NAME))
+        assert_equal(all_jobs[1].origin,
+                     jobs.add_queue_name_prefix(u'my_queue'))
+
+
+class TestGetAllQueues(RQTestBase):
+
+    def test_foreign_queues_are_ignored(self):
+        u'''
+        Test that foreign RQ-queues are ignored.
+        '''
+        # Create queues for this CKAN instance
+        self.enqueue(queue=u'q1')
+        self.enqueue(queue=u'q2')
+        # Create queue for another CKAN instance
+        with changed_config(u'ckan.site_id', u'some-other-ckan-instance'):
+            self.enqueue(queue=u'q2')
+        # Create queue not related to CKAN
+        rq.Queue(u'q4').enqueue_call(jobs.test_job)
+        all_queues = jobs.get_all_queues()
+        names = {jobs.remove_queue_name_prefix(q.name) for q in all_queues}
+        assert_equal(names, {u'q1', u'q2'})
+
+
+class TestGetQueue(RQTestBase):
+
+    def test_get_queue_default_queue(self):
+        u'''
+        Test that the default queue is returned if no queue is given.
+        '''
+        q = jobs.get_queue()
+        assert_equal(jobs.remove_queue_name_prefix(q.name),
+                     jobs.DEFAULT_QUEUE_NAME)
+
+    def test_get_queue_other_queue(self):
+        u'''
+        Test that a different queue can be given.
+        '''
+        q = jobs.get_queue(u'my_queue')
+        assert_equal(jobs.remove_queue_name_prefix(q.name), u'my_queue')
+
+
+class TestJobFromID(RQTestBase):
+
+    def test_job_from_id_existing(self):
+        job = self.enqueue()
+        assert_equal(jobs.job_from_id(job.id), job)
+        job = self.enqueue(queue=u'my_queue')
+        assert_equal(jobs.job_from_id(job.id), job)
+
+    @raises(KeyError)
+    def test_job_from_id_not_existing(self):
+        jobs.job_from_id(u'does-not-exist')
+
+
+class TestDictizeJob(RQTestBase):
+
+    def test_dictize_job(self):
+        job = self.enqueue(title=u'Title', queue=u'my_queue')
+        d = jobs.dictize_job(job)
+        assert_equal(d[u'id'], job.id)
+        assert_equal(d[u'title'], u'Title')
+        assert_equal(d[u'queue'], u'my_queue')
+        dt = datetime.datetime.strptime(d[u'created'], u'%Y-%m-%dT%H:%M:%S')
+        now = datetime.datetime.utcnow()
+        ok_(abs((now - dt).total_seconds()) < 10)
+
+
+def failing_job():
+    u'''
+    A background job that fails.
+    '''
+    raise RuntimeError(u'JOB FAILURE')
+
+
+def database_job(pkg_id, pkg_title):
+    u'''
+    A background job that uses the PostgreSQL database.
+
+    Appends ``pkg_title`` to the title of package ``pkg_id``.
+    '''
+    pkg_dict = call_action(u'package_show', id=pkg_id)
+    pkg_dict[u'title'] += pkg_title
+    pkg_dict = call_action(u'package_update', **pkg_dict)
+
+
+class TestWorker(RQTestBase):
+
+    def test_worker_logging_lifecycle(self):
+        u'''
+        Test that a logger's lifecycle is logged.
+        '''
+        queue = u'my_queue'
+        job = self.enqueue(queue=queue)
+        with recorded_logs(u'ckanext.rq.jobs') as logs:
+            worker = jobs.Worker([queue])
+            worker.work(burst=True)
+        messages = logs.messages[u'info']
+        # We expect 4 log messages: Worker start, job start, job end,
+        # worker end.
+        assert_equal(len(messages), 4)
+        ok_(worker.key in messages[0])
+        ok_(queue in messages[0])
+        ok_(worker.key in messages[1])
+        ok_(job.id in messages[1])
+        ok_(worker.key in messages[2])
+        ok_(job.id in messages[2])
+        ok_(worker.key in messages[3])
+
+    def test_worker_exception_logging(self):
+        u'''
+        Test that exceptions in a job are logged.
+        '''
+        self.enqueue(failing_job)
+        worker = jobs.Worker()
+
+        # Prevent worker from forking so that we can capture log
+        # messages from within the job
+        def execute_job(*args, **kwargs):
+            return worker.perform_job(*args, **kwargs)
+
+        worker.execute_job = execute_job
+        with recorded_logs(u'ckanext.rq.jobs') as logs:
+            worker.work(burst=True)
+        logs.assert_log(u'error', u'JOB FAILURE')
+
+    def test_worker_default_queue(self):
+        self.enqueue()
+        self.enqueue(queue=u'my_queue')
+        jobs.Worker().work(burst=True)
+        all_jobs = self.all_jobs()
+        assert_equal(len(all_jobs), 1)
+        assert_equal(jobs.remove_queue_name_prefix(all_jobs[0].origin),
+                     u'my_queue')
+
+    def test_worker_multiple_queues(self):
+        self.enqueue()
+        self.enqueue(queue=u'queue1')
+        self.enqueue(queue=u'queue2')
+        jobs.Worker([u'queue1', u'queue2']).work(burst=True)
+        all_jobs = self.all_jobs()
+        assert_equal(len(all_jobs), 1)
+        assert_equal(jobs.remove_queue_name_prefix(all_jobs[0].origin),
+                     jobs.DEFAULT_QUEUE_NAME)
+
+    def test_worker_database_access(self):
+        u'''
+        Test database access from within the worker.
+        '''
+        # See https://github.com/ckan/ckan/issues/3243
+        pkg_name = u'test-worker-database-access'
+        try:
+            pkg_dict = call_action(u'package_show', id=pkg_name)
+        except ObjectNotFound:
+            pkg_dict = call_action(u'package_create', name=pkg_name)
+        pkg_dict[u'title'] = u'foo'
+        pkg_dict = call_action(u'package_update', **pkg_dict)
+        titles = u'1 2 3'.split()
+        for title in titles:
+            self.enqueue(database_job, args=[pkg_dict[u'id'], title])
+        jobs.Worker().work(burst=True)
+        # Aside from ensuring that the jobs succeeded, this also checks
+        # that database access still works in the main process.
+        pkg_dict = call_action(u'package_show', id=pkg_name)
+        assert_equal(pkg_dict[u'title'], u'foo' + u''.join(titles))
+
+    def test_fork_within_a_transaction(self):
+        u'''
+        Test forking a worker horse within a database transaction.
+
+        The original instances should be unchanged but their session
+        must be closed.
+        '''
+        pkg_name = u'test-fork-within-a-transaction'
+        model.repo.new_revision()
+        pkg = model.Package.get(pkg_name)
+        if not pkg:
+            pkg = model.Package(name=pkg_name)
+        pkg.title = u'foo'
+        pkg.save()
+        pkg.title = u'bar'
+        self.enqueue(database_job, [pkg.id, u'foo'])
+        jobs.Worker().work(burst=True)
+        assert_equal(pkg.title, u'bar')  # Original instance is unchanged
+        # The original session has been closed, `pkg.Session` uses the new
+        # session in which `pkg` is not registered.
+        assert_false(pkg in pkg.Session)
+        pkg = model.Package.get(pkg.id)  # Get instance from new session
+        assert_equal(pkg.title, u'foofoo')  # Worker only saw committed changes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 rq==0.6.0
 redis==2.10.5             # via rq
+ckantoolkit

--- a/test.ini
+++ b/test.ini
@@ -13,6 +13,7 @@ use = config:../ckan/test-core.ini
 
 # Insert any custom config settings to be used when running your extension's
 # tests here.
+ckan.plugins = rq
 
 
 # Logging configuration


### PR DESCRIPTION
This PR does:

* Register and expose actions (`job_list` etc)
* Cleanup actions code, removing references to other extensions and ensuring support for multiple CKANs
* Ported job tests from ckan core
* Set up travis, running tests on CKAN 2.3 to 2.6 (the ones listed in the readme), eg https://travis-ci.org/amercader/ckanext-rq/builds/293075679